### PR TITLE
fix build related to min/max error

### DIFF
--- a/lib/vis_milkdrop/plugin.cpp
+++ b/lib/vis_milkdrop/plugin.cpp
@@ -472,6 +472,8 @@ Order of Function Calls
 
 */
 
+#include <kodi/Filesystem.h>
+
 #include "plugin.h"
 #include "utility.h"
 #include "support.h"
@@ -483,8 +485,6 @@ Order of Function Calls
 #include <time.h>      // for time()
 //#include <commctrl.h>  // for sliders
 #include <assert.h>
-
-#include <kodi/Filesystem.h>
 
 #define FRAND ((rand() % 7381)/7380.0f)
 #define strnicmp _strnicmp

--- a/lib/vis_milkdrop/utility.cpp
+++ b/lib/vis_milkdrop/utility.cpp
@@ -28,14 +28,14 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <kodi/Filesystem.h>
+
 #include "utility.h"
 #include <stdio.h>
 #include <math.h>
 #include <windows.h>
 //#include <xtl.h>
 #include <d3d9.h>
-
-#include <kodi/Filesystem.h>
 
 float PowCosineInterp(float x, float pow)
 {

--- a/visualization.milkdrop/addon.xml.in
+++ b/visualization.milkdrop/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.milkdrop"
-  version="2.3.1"
+  version="2.3.2"
   name="MilkDrop"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
To fix this errors:
```
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2589: "(": Ungültiges Token auf der rechten Seite von "::" [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2062: "unknown-type"-Typ unerwartet [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2059: Syntaxfehler: ")" [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
```

There becomes it complicated about the std::min/max usage as the needed `NOMINMAX` was not available, also via cmake defines it not worked.
It seems some new included OS header unset the NOMINMAX somewhere.