### PR TITLE
Fix build with Visual Studio 2019/2022

### DIFF
--- a/lib/vis_milkdrop/ns-eel2/nseel-compiler.c
+++ b/lib/vis_milkdrop/ns-eel2/nseel-compiler.c
@@ -476,7 +476,10 @@ static EEL_F onepointfive=1.5f;
 static EEL_F g_closefact = NSEEL_CLOSEFACTOR;
 static const EEL_F eel_zero=0.0, eel_one=1.0;
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400
+#if defined(_MSC_VER) && _MSC_VER >= 1920
+static double intrin_floor(double a) { return __floor(a); }
+static double intrin_ceil(double a) { return __ceil(a); }
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
 static double __floor(double a) { return floor(a); }
 static double __ceil(double a) { return ceil(a); }
 #endif
@@ -574,7 +577,10 @@ static functionType fnTable1[] = {
 #endif
 	 { "rand",   nseel_asm_1pp,nseel_asm_1pp_end,  1, {&nseel_int_rand}, } ,
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400
+#if defined(_MSC_VER) && _MSC_VER >= 1920
+   { "floor",  nseel_asm_1pdd,nseel_asm_1pdd_end, 1, {&intrin_floor} },
+   { "ceil",   nseel_asm_1pdd,nseel_asm_1pdd_end,  1, {&intrin_ceil} },
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
    { "floor",  nseel_asm_1pdd,nseel_asm_1pdd_end, 1, {&__floor} },
    { "ceil",   nseel_asm_1pdd,nseel_asm_1pdd_end,  1, {&__ceil} },
 #else


### PR DESCRIPTION
Since Jenkins was updated to Visual Studio 2019 `visualitzation.milkdrop` cannot be compiled on UWP.

See https://jenkins.kodi.tv/view/Windows/job/WIN-UWP-64/17310/

Error is:
visualization.milkdrop\lib\vis_milkdrop\ns-eel2\nseel-compiler.c(480): error C2169: '__floor': intrinsic function, cannot be defined

The reason is the already exist `__floor` symbol defined (intrinsic version of floor) and cannot be redefined. I guess in early VS versions can be re-defined.

also `__floor` cannot be used directly because:

visualization.milkdrop\lib\vis_milkdrop\ns-eel2\nseel-compiler.c(578): error C7552: '__floor': purely intrinsic functions have no address

and changing code to:
`{ "floor",  nseel_asm_1pdd,nseel_asm_1pdd_end, 1, {__floor} },`

compiles fine but has linker error.

Workaround is define new function `intrin_floor` that uses intrinsic version of floor() and use it instead of `__floor` directly.

Same for `__ceil`.

Another possible solution would be not to use the intrinsic versions...