### PR TITLE
Fix UWP build after recent build environment updates (C++ 20)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,12 +33,12 @@ jobs:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: Win32
           CONFIGURATION: Release
-          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
         Win64-UWP:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
-          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
         #ARM32-UWP:
         #  GENERATOR: "Visual Studio 17 2022"
         #  ARCHITECTURE: ARM

--- a/lib/vis_milkdrop/CMakeLists.txt
+++ b/lib/vis_milkdrop/CMakeLists.txt
@@ -48,6 +48,9 @@ else()
   add_definitions(-D_WIN32_WINNT=0x0600 -D_WINDOWS)
 endif()
 remove_definitions(-D_USE_32BIT_TIME_T)
+
+add_compile_options(/Zc:strictStrings-)
+
 add_library(vis_milkdrop STATIC ${SOURCES} ${SHADER_INCLUDES})
 
 target_link_libraries(vis_milkdrop ns-eel2)


### PR DESCRIPTION
Currently UWP-64 build is broken (Xbox).

Seems is since Piers branched, maybe because use of C++20 is also propagated to binary add-ons and enforces more strict conformance.

This "fixes" multiple errors of type:

```
C:\jenkws\workspace\WIN-UWP-64\cmake\addons\build\visualization.milkdrop\lib\vis_milkdrop\plugin.cpp(4696): error C2664: 'void CState::Import(char *,char *)': cannot convert argument 1 from 'const char [9]' to 'char *'
C:\jenkws\workspace\WIN-UWP-64\cmake\addons\build\visualization.milkdrop\lib\vis_milkdrop\plugin.cpp(4696): note: Conversion from string literal loses const qualifier (see /Zc:strictStrings)
```

Code itself not fixed/changed as is external lib code.

Also is needed update Windows SDK in azure pipelines to fix other errors.



